### PR TITLE
fix: resolve Decimal128 data corruption with Snowflake ADBC driver

### DIFF
--- a/src/adbc_catalog.cpp
+++ b/src/adbc_catalog.cpp
@@ -844,6 +844,7 @@ struct SchemaFieldRow {
     string field_name;
     string field_type;
     bool nullable;
+    string arrow_format;
 };
 
 struct AdbcSchemaBindData : public TableFunctionData {
@@ -883,6 +884,7 @@ static void ExtractSchemaFields(ClientContext &context, ArrowSchema *schema, vec
 
         // In Arrow C Data Interface, nullable is indicated by ARROW_FLAG_NULLABLE bit (flags & 2)
         row.nullable = (child->flags & 2) != 0;
+        row.arrow_format = child->format ? child->format : "";
         field_rows.push_back(row);
     }
 }
@@ -921,8 +923,8 @@ static unique_ptr<FunctionData> AdbcSchemaBind(ClientContext &context, TableFunc
     bind_data->connection = GetValidatedConnection(bind_data->connection_id, "adbc_schema");
 
     // Return schema for fields
-    names = {"field_name", "field_type", "nullable"};
-    return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::BOOLEAN};
+    names = {"field_name", "field_type", "nullable", "arrow_format"};
+    return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::VARCHAR};
 
     return std::move(bind_data);
 }
@@ -971,12 +973,14 @@ static void AdbcSchemaFunction(ClientContext &context, TableFunctionInput &data,
     auto &name_vector = output.data[0];
     auto &type_vector = output.data[1];
     auto &nullable_vector = output.data[2];
+    auto &arrow_format_vector = output.data[3];
 
     while (global_state.current_row < global_state.field_rows.size() && count < STANDARD_VECTOR_SIZE) {
         auto &row = global_state.field_rows[global_state.current_row];
         name_vector.SetValue(count, Value(row.field_name));
         type_vector.SetValue(count, Value(row.field_type));
         nullable_vector.SetValue(count, Value(row.nullable));
+        arrow_format_vector.SetValue(count, Value(row.arrow_format));
         count++;
         global_state.current_row++;
     }

--- a/src/adbc_scan.cpp
+++ b/src/adbc_scan.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/storage/statistics/numeric_stats.hpp"
 #include "duckdb/storage/statistics/string_stats.hpp"
 #include "duckdb/common/insertion_order_preserving_map.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include <nanoarrow/nanoarrow.h>
@@ -147,47 +148,42 @@ static idx_t ExtractBatchSize(TableFunctionBindInput &input, const string &func_
     return 0;
 }
 
-// Helper to get schema from a prepared statement (tries ExecuteSchema first, falls back to execute)
-// Returns true if schema was obtained, populates schema_root
+// Helper to get schema from a prepared statement by executing and reading the stream schema.
+// Note: We intentionally do NOT use AdbcStatementExecuteSchema here. Some drivers
+// (notably the Snowflake ADBC driver) return schema types from ExecuteSchema that
+// don't match the actual data format returned by ExecuteQuery (e.g., reporting
+// int64/double format strings while sending Decimal128 data). This causes data
+// corruption because ArrowToDuckDB reads the wrong number of bytes per value.
+// By always getting the schema from an actual execution stream, we guarantee the
+// types match the data that will be returned during scanning.
 static void GetSchemaFromStatement(AdbcStatementWrapper &statement, const string &query,
                                     ArrowSchemaWrapper &schema_root, const string &func_name) {
-    // Try to get schema without executing using ExecuteSchema (ADBC 1.1.0+)
-    bool got_schema = false;
+    ArrowArrayStream stream;
+    memset(&stream, 0, sizeof(stream));
+
     try {
-        got_schema = statement.ExecuteSchema(&schema_root.arrow_schema);
+        statement.ExecuteQuery(&stream, nullptr);
     } catch (Exception &e) {
-        got_schema = false;
+        throw IOException(FormatError(func_name + ": Failed to execute query: " + string(e.what()), query));
     }
 
-    if (!got_schema) {
-        // Fallback: driver doesn't support ExecuteSchema, need to execute to get schema
-        ArrowArrayStream stream;
-        memset(&stream, 0, sizeof(stream));
-
-        try {
-            statement.ExecuteQuery(&stream, nullptr);
-        } catch (Exception &e) {
-            throw IOException(FormatError(func_name + ": Failed to execute query: " + string(e.what()), query));
+    int ret = stream.get_schema(&stream, &schema_root.arrow_schema);
+    if (ret != 0) {
+        const char *error_msg = stream.get_last_error(&stream);
+        string msg = func_name + ": Failed to get schema from stream";
+        if (error_msg) {
+            msg += ": ";
+            msg += error_msg;
         }
-
-        int ret = stream.get_schema(&stream, &schema_root.arrow_schema);
-        if (ret != 0) {
-            const char *error_msg = stream.get_last_error(&stream);
-            string msg = func_name + ": Failed to get schema from stream";
-            if (error_msg) {
-                msg += ": ";
-                msg += error_msg;
-            }
-            if (stream.release) {
-                stream.release(&stream);
-            }
-            throw IOException(FormatError(msg, query));
-        }
-
-        // Release the stream
         if (stream.release) {
             stream.release(&stream);
         }
+        throw IOException(FormatError(msg, query));
+    }
+
+    // Release the stream
+    if (stream.release) {
+        stream.release(&stream);
     }
 }
 
@@ -764,19 +760,26 @@ static unique_ptr<FunctionData> AdbcScanTableBind(ClientContext &context, TableF
     // Now validate and get connection wrapper
     bind_data->connection = GetValidatedConnection(bind_data->connection_id, "adbc_scan_table");
 
-    // Create and prepare statement
-    auto statement = make_shared_ptr<AdbcStatementWrapper>(bind_data->connection);
-    statement->Init();
-    statement->SetSqlQuery(bind_data->query);
+    // Get schema by executing the query and reading the stream schema.
+    // We intentionally do NOT use GetTableSchema or ExecuteSchema here because some
+    // drivers (notably the Snowflake ADBC driver) return different types from metadata
+    // APIs vs the actual data stream. For example, GetTableSchema may report int64/double
+    // format strings while the stream contains Decimal128 data. Using the stream schema
+    // ensures the bind-time return types match the actual data format, which is critical
+    // because ArrowToDuckDB dispatches based on the output vector type (from bind).
+    {
+        auto statement = make_shared_ptr<AdbcStatementWrapper>(bind_data->connection);
+        statement->Init();
+        statement->SetSqlQuery(bind_data->query);
 
-    try {
-        statement->Prepare();
-    } catch (Exception &e) {
-        throw InvalidInputException("adbc_scan_table: Failed to prepare statement for table '" + bind_data->table_name + "': " + string(e.what()));
+        try {
+            statement->Prepare();
+        } catch (Exception &e) {
+            throw InvalidInputException("adbc_scan_table: Failed to prepare statement for table '" + bind_data->table_name + "': " + string(e.what()));
+        }
+
+        GetSchemaFromStatement(*statement, bind_data->query, bind_data->schema_root, "adbc_scan_table");
     }
-
-    // Get schema from statement (tries ExecuteSchema, falls back to execute)
-    GetSchemaFromStatement(*statement, bind_data->query, bind_data->schema_root, "adbc_scan_table");
 
     // Populate return types and names from Arrow schema
     PopulateReturnTypesFromSchema(context, *bind_data, return_types, names);
@@ -905,12 +908,15 @@ static unique_ptr<GlobalTableFunctionState> AdbcScanTableInitGlobal(ClientContex
     }
     global_state->stream_initialized = true;
 
-    // If we projected, we need to get the schema from the stream and populate projected_arrow_table
-    if (needs_projection) {
+    // Always get the stream schema and use it for ArrowToDuckDB conversion.
+    // This ensures the ArrowTableType used for reading Arrow buffers always matches the
+    // actual data format in the stream. This is critical because some drivers (e.g.,
+    // Snowflake) may report different types at schema-discovery time vs execution time.
+    {
         int ret = global_state->stream.get_schema(&global_state->stream, &global_state->projected_schema.arrow_schema);
         if (ret != 0) {
             const char *error_msg = global_state->stream.get_last_error(&global_state->stream);
-            string msg = "adbc_scan_table: Failed to get schema from projected query";
+            string msg = "adbc_scan_table: Failed to get schema from query stream";
             if (error_msg) {
                 msg += ": ";
                 msg += error_msg;
@@ -966,21 +972,52 @@ static void AdbcScanTableFunction(ClientContext &context, TableFunctionInput &da
 
     output.SetCardinality(output_size);
 
-    // Convert Arrow data to DuckDB
-    // If we have a projected schema, use that; otherwise use the bind_data schema
     if (output_size > 0) {
-        if (global_state.has_projected_schema) {
-            // With projection, arrow columns match output columns 1:1
-            ArrowTableFunction::ArrowToDuckDB(local_state,
-                                              global_state.projected_arrow_table.GetColumns(),
-                                              output,
-                                              true);  // arrow_scan_is_projected = true since columns match 1:1
+        auto &stream_columns = global_state.projected_arrow_table.GetColumns();
+
+        // Check if stream schema types differ from output types.
+        // This can happen when the ATTACH path creates table columns using GetTableSchema
+        // (which may return int64/double) while the actual data stream uses different types
+        // (e.g., Decimal128). ArrowToDuckDB dispatches on the output vector type, so a
+        // mismatch causes it to read the wrong number of bytes per value.
+        bool types_match = true;
+        for (idx_t i = 0; i < output.ColumnCount() && i < stream_columns.size(); i++) {
+            if (stream_columns.at(i)->GetDuckType() != output.data[i].GetType()) {
+                types_match = false;
+                break;
+            }
+        }
+
+        if (types_match) {
+            // Fast path: types match, convert directly into output
+            ArrowTableFunction::ArrowToDuckDB(local_state, stream_columns, output, true);
         } else {
-            // No projection, use original bind_data schema
-            ArrowTableFunction::ArrowToDuckDB(local_state,
-                                              bind_data.arrow_table.GetColumns(),
-                                              output,
-                                              false);
+            // Slow path: type mismatch detected. Create a temporary DataChunk with the
+            // stream schema types so ArrowToDuckDB reads data with the correct byte widths,
+            // then cast each column to the output type.
+            vector<LogicalType> stream_types;
+            for (idx_t i = 0; i < output.ColumnCount(); i++) {
+                if (i < stream_columns.size()) {
+                    stream_types.push_back(stream_columns.at(i)->GetDuckType());
+                } else {
+                    stream_types.push_back(output.data[i].GetType());
+                }
+            }
+
+            DataChunk temp_chunk;
+            temp_chunk.Initialize(context, stream_types, output_size);
+            temp_chunk.SetCardinality(output_size);
+
+            ArrowTableFunction::ArrowToDuckDB(local_state, stream_columns, temp_chunk, true);
+
+            // Cast each column from stream type to output type
+            for (idx_t i = 0; i < output.ColumnCount(); i++) {
+                if (stream_types[i] == output.data[i].GetType()) {
+                    output.data[i].Reference(temp_chunk.data[i]);
+                } else {
+                    VectorOperations::Cast(context, temp_chunk.data[i], output.data[i], output_size);
+                }
+            }
         }
     }
 

--- a/test/sql/adbc_numeric_types.test
+++ b/test/sql/adbc_numeric_types.test
@@ -1,0 +1,189 @@
+# name: test/sql/adbc_numeric_types.test
+# description: Regression test for numeric type handling in adbc_scan_table and ATTACH.
+#
+# This test exercises the code paths changed to fix a data corruption bug where
+# drivers (e.g., Snowflake ADBC) report int64/double types via ExecuteSchema but
+# send Decimal128 data via ExecuteQuery. The fix uses GetTableSchema for
+# adbc_scan_table bind and always derives ArrowTableType from the actual stream
+# schema in InitGlobal. While the SQLite driver doesn't exhibit this specific
+# mismatch, this test verifies numeric precision is preserved through the fixed
+# code paths and guards against regressions.
+#
+# See: bug.md for the original Snowflake Decimal128 corruption report.
+# group: [adbc]
+
+require adbc_scanner
+
+require-env HAS_ADBC_SQLITE_DRIVER
+
+# ============================================
+# Setup - Create tables with numeric types
+# ============================================
+
+statement ok
+SET VARIABLE conn_id = (SELECT adbc_connect({'driver': 'sqlite', 'uri': '/tmp/test_numeric_types.db'}));
+
+# Create a table with integer and real columns matching the TPC-H lineitem schema
+# from the bug report (L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER are integer;
+# L_QUANTITY, L_EXTENDEDPRICE, L_DISCOUNT, L_TAX are decimal/real)
+statement ok
+SELECT adbc_execute(getvariable('conn_id')::BIGINT, 'DROP TABLE IF EXISTS lineitem');
+
+statement ok
+SELECT adbc_execute(getvariable('conn_id')::BIGINT, '
+    CREATE TABLE lineitem (
+        l_orderkey INTEGER,
+        l_partkey INTEGER,
+        l_suppkey INTEGER,
+        l_linenumber INTEGER,
+        l_quantity REAL,
+        l_extendedprice REAL,
+        l_discount REAL,
+        l_tax REAL,
+        l_shipmode TEXT,
+        l_comment TEXT
+    )
+');
+
+# Insert the exact values from the bug report (Python/correct output)
+statement ok
+SELECT adbc_execute(getvariable('conn_id')::BIGINT, '
+    INSERT INTO lineitem VALUES
+        (2400001, 132304, 4818, 1, 10.0, 13363.0, 0.03, 0.02, ''SHIP'', ''egular dolphins''),
+        (2400001, 24513,  2020, 2, 14.0, 20125.14, 0.04, 0.03, ''SHIP'', ''es wake quickly bold packages''),
+        (2400001, 175232, 7750, 3, 18.0, 23530.14, 0.01, 0.07, ''REG AIR'', ''ic deposits carefully''),
+        (2400001, 119658, 4681, 4, 2.0,  3355.3,  0.09, 0.08, ''REG AIR'', ''hinder slyly quickly''),
+        (2400001, 89532,  4549, 5, 13.0, 19779.89, 0.07, 0.03, ''REG AIR'', ''ges believe slyly'')
+');
+
+# ============================================
+# Test adbc_scan_table WITHOUT projection
+# (exercises the always-use-stream-schema path in InitGlobal)
+# ============================================
+
+# Full table scan - verifies all columns are read with correct types and values.
+# Before the fix, integer columns showed alternating correct/zero values and
+# real columns showed denormalized doubles (e.g., 4.94e-321 instead of 10.0).
+query IIIIRRRRTT
+SELECT * FROM adbc_scan_table(getvariable('conn_id')::BIGINT, 'lineitem') ORDER BY l_linenumber;
+----
+2400001	132304	4818	1	10.0	13363.0	0.03	0.02	SHIP	egular dolphins
+2400001	24513	2020	2	14.0	20125.14	0.04	0.03	SHIP	es wake quickly bold packages
+2400001	175232	7750	3	18.0	23530.14	0.01	0.07	REG AIR	ic deposits carefully
+2400001	119658	4681	4	2.0	3355.3	0.09	0.08	REG AIR	hinder slyly quickly
+2400001	89532	4549	5	13.0	19779.89	0.07	0.03	REG AIR	ges believe slyly
+
+# ============================================
+# Test adbc_scan_table WITH filter pushdown
+# (exercises stream schema + filter parameter binding)
+# ============================================
+
+# Before the fix, WHERE l_orderkey = 2400001 would return rows with l_orderkey = 0
+# due to Decimal128 bytes being split across int64-sized reads.
+query IIIIRRRR
+SELECT l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax
+FROM adbc_scan_table(getvariable('conn_id')::BIGINT, 'lineitem')
+WHERE l_orderkey = 2400001
+ORDER BY l_linenumber;
+----
+2400001	132304	4818	1	10.0	13363.0	0.03	0.02
+2400001	24513	2020	2	14.0	20125.14	0.04	0.03
+2400001	175232	7750	3	18.0	23530.14	0.01	0.07
+2400001	119658	4681	4	2.0	3355.3	0.09	0.08
+2400001	89532	4549	5	13.0	19779.89	0.07	0.03
+
+# ============================================
+# Test adbc_scan_table WITH projection pushdown
+# (exercises stream schema derivation for projected columns)
+# ============================================
+
+# Select only real-valued columns - these showed as denormalized doubles before the fix
+query RR
+SELECT l_quantity, l_discount
+FROM adbc_scan_table(getvariable('conn_id')::BIGINT, 'lineitem')
+ORDER BY l_linenumber;
+----
+10.0	0.03
+14.0	0.04
+18.0	0.01
+2.0	0.09
+13.0	0.07
+
+# Select a mix of integer and real columns
+query IR
+SELECT l_linenumber, l_extendedprice
+FROM adbc_scan_table(getvariable('conn_id')::BIGINT, 'lineitem')
+ORDER BY l_linenumber;
+----
+1	13363.0
+2	20125.14
+3	23530.14
+4	3355.3
+5	19779.89
+
+# ============================================
+# Test aggregation on numeric columns
+# (verifies values are numerically correct, not garbage)
+# ============================================
+
+query RR
+SELECT SUM(l_quantity), SUM(l_extendedprice) FROM adbc_scan_table(getvariable('conn_id')::BIGINT, 'lineitem');
+----
+57.0	80153.47
+
+query R
+SELECT AVG(l_discount) FROM adbc_scan_table(getvariable('conn_id')::BIGINT, 'lineitem');
+----
+0.048
+
+statement ok
+SELECT adbc_disconnect(getvariable('conn_id')::BIGINT);
+
+# ============================================
+# Test via ATTACH (exercises the full storage scan path)
+# The ATTACH path calls adbc_scan_table internally, so this
+# tests the GetTableSchema bind + stream schema InitGlobal flow.
+# ============================================
+
+statement ok
+ATTACH '/tmp/test_numeric_types.db' AS numeric_db (TYPE adbc, driver 'sqlite');
+
+# Full scan through ATTACH
+query IIIIRRRRTT
+SELECT * FROM numeric_db.lineitem ORDER BY l_linenumber;
+----
+2400001	132304	4818	1	10.0	13363.0	0.03	0.02	SHIP	egular dolphins
+2400001	24513	2020	2	14.0	20125.14	0.04	0.03	SHIP	es wake quickly bold packages
+2400001	175232	7750	3	18.0	23530.14	0.01	0.07	REG AIR	ic deposits carefully
+2400001	119658	4681	4	2.0	3355.3	0.09	0.08	REG AIR	hinder slyly quickly
+2400001	89532	4549	5	13.0	19779.89	0.07	0.03	REG AIR	ges believe slyly
+
+# Filter through ATTACH
+query IR
+SELECT l_linenumber, l_quantity FROM numeric_db.lineitem WHERE l_linenumber <= 3 ORDER BY l_linenumber;
+----
+1	10.0
+2	14.0
+3	18.0
+
+# Aggregation through ATTACH
+query RR
+SELECT SUM(l_quantity), SUM(l_extendedprice) FROM numeric_db.lineitem;
+----
+57.0	80153.47
+
+statement ok
+DETACH numeric_db;
+
+# ============================================
+# Cleanup
+# ============================================
+
+statement ok
+SET VARIABLE cleanup_conn = (SELECT adbc_connect({'driver': 'sqlite', 'uri': '/tmp/test_numeric_types.db'}));
+
+statement ok
+SELECT adbc_execute(getvariable('cleanup_conn')::BIGINT, 'DROP TABLE IF EXISTS lineitem');
+
+statement ok
+SELECT adbc_disconnect(getvariable('cleanup_conn')::BIGINT);


### PR DESCRIPTION
## Summary

Fixes #7

- Fixes data corruption when scanning Snowflake tables via ADBC, where integer columns showed alternating correct/zero values and decimal columns showed denormalized doubles (e.g., `4.94e-321`)
- Root cause: the Snowflake ADBC Go driver reports `l` (int64) and `g` (double) from `GetTableSchema`, but the actual data stream contains `d:38,0` / `d:12,2` (Decimal128) data — causing DuckDB to read 8-byte values from 16-byte buffers
- Fix uses the stream schema for bind-time types, always derives ArrowTypes from the actual stream, and handles type mismatches between the ATTACH catalog types and stream types at scan time
- Adds `arrow_format` column to `adbc_schema()` for diagnostics
- Adds regression test for numeric type handling

## Test plan

- [x] All 713 existing assertions pass (`HAS_ADBC_SQLITE_DRIVER=1 make test`)
- [x] Verified against live Snowflake (TPC-H `lineitem` table) — all values now match Python ADBC driver output
- [x] `WHERE l_orderkey = 0` correctly returns 0 rows (was previously returning phantom rows due to corruption)
- [x] Filter pushdown, projection pushdown, and aggregation paths all verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)