### PR TITLE
fix(adbc_insert): bounded queue + concurrent ExecuteUpdate for flat-RSS streaming

### DIFF
--- a/src/adbc_insert.cpp
+++ b/src/adbc_insert.cpp
@@ -7,9 +7,32 @@
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include <nanoarrow/nanoarrow.h>
 #include <queue>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <cstdlib>
 
 namespace adbc_scanner {
 using namespace duckdb;
+
+// Default upper bound on the number of Arrow record batches buffered between the
+// DuckDB producer (AdbcInsertInOut) and the ADBC driver consumer (ExecuteUpdate
+// → GetNext). Each DuckDB DataChunk is at most STANDARD_VECTOR_SIZE (2048) rows,
+// so this caps resident memory at roughly N * 2048 * row_width rather than the
+// full source size. Overridable via ADBC_INSERT_MAX_PENDING_BATCHES.
+static constexpr size_t DEFAULT_MAX_PENDING_BATCHES = 32;
+
+static size_t ResolveMaxPendingBatches() {
+    const char *env = std::getenv("ADBC_INSERT_MAX_PENDING_BATCHES");
+    if (env && *env) {
+        char *end = nullptr;
+        long v = std::strtol(env, &end, 10);
+        if (end != env && v > 0) {
+            return static_cast<size_t>(v);
+        }
+    }
+    return DEFAULT_MAX_PENDING_BATCHES;
+}
 
 struct AdbcInsertBindData : public TableFunctionData {
     int64_t connection_id;
@@ -20,18 +43,38 @@ struct AdbcInsertBindData : public TableFunctionData {
     vector<string> input_names;
 };
 
-// Custom ArrowArrayStream that we can feed batches into
-// This allows us to use BindStream for proper streaming ingestion
+// Bounded, blocking ArrowArrayStream bridging the DuckDB producer and the ADBC
+// driver consumer.
+//
+// The driver pulls batches via GetNext from inside AdbcStatement::ExecuteUpdate,
+// which we run on a dedicated thread (see AdbcInsertGlobalState). The DuckDB
+// execution engine pushes batches via AddBatch from the (single) in-out worker.
+// A bounded queue with two condition variables provides backpressure in both
+// directions:
+//   - AddBatch blocks when the queue is full until the consumer drains one
+//     (this is what keeps RSS flat — DuckDB stops decoding ahead of the driver).
+//   - GetNext blocks when the queue is empty until the producer pushes one or
+//     signals completion.
+// Abort()/consumer-stop signalling prevents either side from deadlocking when
+// the other fails or the query is cancelled.
 struct AdbcInsertStream {
     ArrowArrayStream stream;
     ArrowSchema schema;
     bool schema_set = false;
-    queue<ArrowArray> pending_batches;
-    mutex lock;
-    bool finished = false;
-    string last_error;
 
-    AdbcInsertStream() {
+    std::mutex lock;
+    std::condition_variable cv_not_empty;  // consumer waits for a batch
+    std::condition_variable cv_not_full;   // producer waits for free space
+    std::queue<ArrowArray> pending_batches;
+    size_t max_batches;
+
+    bool finished = false;          // producer: no more batches will arrive
+    bool aborted = false;           // hard stop: consumer should error out
+    bool consumer_stopped = false;  // consumer thread has exited (ok or error)
+    string consumer_error;          // error message from the consumer side
+    string last_error;              // surfaced to the driver via get_last_error
+
+    explicit AdbcInsertStream(size_t max_batches_p) : max_batches(max_batches_p) {
         memset(&stream, 0, sizeof(stream));
         memset(&schema, 0, sizeof(schema));
         stream.private_data = this;
@@ -45,7 +88,6 @@ struct AdbcInsertStream {
         if (schema.release) {
             schema.release(&schema);
         }
-        // Release any pending batches
         while (!pending_batches.empty()) {
             auto &batch = pending_batches.front();
             if (batch.release) {
@@ -56,7 +98,7 @@ struct AdbcInsertStream {
     }
 
     void SetSchema(ArrowSchema *new_schema) {
-        lock_guard<mutex> l(lock);
+        std::lock_guard<std::mutex> l(lock);
         if (schema.release) {
             schema.release(&schema);
         }
@@ -65,45 +107,94 @@ struct AdbcInsertStream {
         schema_set = true;
     }
 
-    void AddBatch(ArrowArray *batch) {
-        lock_guard<mutex> l(lock);
+    // Producer side. Blocks while the queue is full to apply backpressure.
+    // Returns false if the consumer has stopped/aborted and the batch could not
+    // be handed off (the batch is released in that case).
+    bool AddBatch(ArrowArray *batch) {
+        std::unique_lock<std::mutex> l(lock);
+        cv_not_full.wait(l, [&] {
+            return pending_batches.size() < max_batches || consumer_stopped || aborted;
+        });
+        if (consumer_stopped || aborted) {
+            if (batch->release) {
+                batch->release(batch);
+            }
+            memset(batch, 0, sizeof(*batch));
+            return false;
+        }
         pending_batches.push(*batch);
         memset(batch, 0, sizeof(*batch));  // Transfer ownership
+        cv_not_empty.notify_one();
+        return true;
     }
 
+    // Producer side: no more batches will be produced.
     void Finish() {
-        lock_guard<mutex> l(lock);
+        std::lock_guard<std::mutex> l(lock);
         finished = true;
+        cv_not_empty.notify_all();
+    }
+
+    // Hard abort (query cancelled or producer errored). Wakes both sides; the
+    // next GetNext returns an error so ExecuteUpdate unwinds without ingesting a
+    // partial result.
+    void Abort(const string &reason) {
+        std::lock_guard<std::mutex> l(lock);
+        aborted = true;
+        if (last_error.empty()) {
+            last_error = reason;
+        }
+        cv_not_empty.notify_all();
+        cv_not_full.notify_all();
+    }
+
+    // Consumer side: record that the ExecuteUpdate thread has exited so a blocked
+    // producer can stop waiting.
+    void MarkConsumerStopped(const string &error) {
+        std::lock_guard<std::mutex> l(lock);
+        consumer_stopped = true;
+        if (!error.empty()) {
+            consumer_error = error;
+        }
+        cv_not_full.notify_all();
+    }
+
+    string GetConsumerError() {
+        std::lock_guard<std::mutex> l(lock);
+        return consumer_error;
     }
 
     static int GetSchema(ArrowArrayStream *stream, ArrowSchema *out) {
         auto *self = static_cast<AdbcInsertStream *>(stream->private_data);
-        lock_guard<mutex> l(self->lock);
+        std::lock_guard<std::mutex> l(self->lock);
         if (!self->schema_set) {
             self->last_error = "Schema not set";
             return EINVAL;
         }
-        // Copy the schema (don't transfer ownership)
         return ArrowSchemaDeepCopy(&self->schema, out);
     }
 
     static int GetNext(ArrowArrayStream *stream, ArrowArray *out) {
         auto *self = static_cast<AdbcInsertStream *>(stream->private_data);
-        lock_guard<mutex> l(self->lock);
+        std::unique_lock<std::mutex> l(self->lock);
+        self->cv_not_empty.wait(l, [&] {
+            return !self->pending_batches.empty() || self->finished || self->aborted;
+        });
+
+        if (self->aborted && self->pending_batches.empty()) {
+            self->last_error = "adbc_insert: ingestion aborted";
+            return EIO;
+        }
 
         if (self->pending_batches.empty()) {
-            if (self->finished) {
-                // Signal end of stream
-                memset(out, 0, sizeof(*out));
-                return 0;
-            }
-            // No batches available yet - this shouldn't happen in our usage
-            self->last_error = "No batches available";
-            return EAGAIN;
+            // finished and fully drained → end of stream
+            memset(out, 0, sizeof(*out));
+            return 0;
         }
 
         *out = self->pending_batches.front();
         self->pending_batches.pop();
+        self->cv_not_full.notify_one();
         return 0;
     }
 
@@ -113,7 +204,7 @@ struct AdbcInsertStream {
     }
 
     static void Release(ArrowArrayStream *stream) {
-        // Don't delete - we manage lifetime externally
+        // Lifetime managed externally (by AdbcInsertGlobalState).
         stream->release = nullptr;
     }
 };
@@ -124,11 +215,50 @@ struct AdbcInsertGlobalState : public GlobalTableFunctionState {
     unique_ptr<AdbcInsertStream> insert_stream;
     int64_t rows_inserted = 0;
     bool stream_bound = false;
-    bool executed = false;
     ClientProperties client_properties;
 
+    // Background consumer: runs AdbcStatement::ExecuteUpdate, which pulls from
+    // insert_stream via GetNext concurrently with the producer pushing batches.
+    std::thread exec_thread;
+    bool exec_ok = false;
+    string exec_error;
+    int64_t exec_rows_affected = -1;
+
     idx_t MaxThreads() const override {
-        return 1;
+        return 1;  // single producer — keep AddBatch ordering simple
+    }
+
+    void StartConsumer() {
+        exec_thread = std::thread([this]() {
+            try {
+                statement->ExecuteUpdate(&exec_rows_affected);
+                exec_ok = true;
+                insert_stream->MarkConsumerStopped(string());
+            } catch (std::exception &e) {
+                exec_ok = false;
+                exec_error = e.what();
+                insert_stream->MarkConsumerStopped(exec_error);
+            } catch (...) {
+                exec_ok = false;
+                exec_error = "unknown error during ExecuteUpdate";
+                insert_stream->MarkConsumerStopped(exec_error);
+            }
+        });
+    }
+
+    void JoinConsumer() {
+        if (exec_thread.joinable()) {
+            exec_thread.join();
+        }
+    }
+
+    ~AdbcInsertGlobalState() override {
+        // Abnormal teardown (producer threw, query cancelled): make sure the
+        // consumer thread can never block forever, then join it.
+        if (insert_stream && exec_thread.joinable()) {
+            insert_stream->Abort("adbc_insert: aborted before completion");
+        }
+        JoinConsumer();
     }
 };
 
@@ -206,8 +336,8 @@ static unique_ptr<GlobalTableFunctionState> AdbcInsertInitGlobal(ClientContext &
     }
     global_state->statement->SetOption("adbc.ingest.mode", mode_value);
 
-    // Create the insert stream
-    global_state->insert_stream = make_uniq<AdbcInsertStream>();
+    // Create the bounded insert stream
+    global_state->insert_stream = make_uniq<AdbcInsertStream>(ResolveMaxPendingBatches());
 
     // Set up the schema from the input types
     ArrowSchema schema;
@@ -215,13 +345,18 @@ static unique_ptr<GlobalTableFunctionState> AdbcInsertInitGlobal(ClientContext &
                                    global_state->client_properties);
     global_state->insert_stream->SetSchema(&schema);
 
-    // Bind the stream to the statement
+    // Bind the stream to the statement (stores the stream; does not consume yet)
     try {
         global_state->statement->BindStream(&global_state->insert_stream->stream);
         global_state->stream_bound = true;
     } catch (Exception &e) {
         throw IOException("adbc_insert: Failed to bind stream: " + string(e.what()));
     }
+
+    // Start draining concurrently: ExecuteUpdate runs on its own thread and
+    // pulls batches from the bound stream as we push them. Without this overlap
+    // the queue would have to hold the entire source before ExecuteUpdate ran.
+    global_state->StartConsumer();
 
     return std::move(global_state);
 }
@@ -245,8 +380,14 @@ static OperatorResultType AdbcInsertInOut(ExecutionContext &context, TableFuncti
 
     ArrowArray arr = appender.Finalize();
 
-    // Add the batch to our stream
-    global_state.insert_stream->AddBatch(&arr);
+    // Hand the batch to the consumer; blocks for backpressure when the queue is
+    // full. Returns false only if the consumer thread already stopped (error /
+    // cancellation) — surface that as a query error.
+    if (!global_state.insert_stream->AddBatch(&arr)) {
+        string err = global_state.insert_stream->GetConsumerError();
+        throw IOException("adbc_insert: ingestion stopped early: " +
+                          (err.empty() ? string("consumer terminated") : err));
+    }
     global_state.rows_inserted += input.size();
 
     // Don't output anything during processing - we output the total at the end
@@ -260,21 +401,16 @@ static OperatorFinalizeResultType AdbcInsertFinalize(ExecutionContext &context, 
     auto &global_state = data_p.global_state->Cast<AdbcInsertGlobalState>();
     lock_guard<mutex> l(global_state.lock);
 
-    // Mark the stream as finished
+    // Signal end of input, then wait for ExecuteUpdate to finish draining.
     global_state.insert_stream->Finish();
+    global_state.JoinConsumer();
 
-    // Execute the statement to perform the actual insert
-    if (!global_state.executed && global_state.stream_bound) {
-        int64_t rows_affected = -1;
-        try {
-            global_state.statement->ExecuteUpdate(&rows_affected);
-            global_state.executed = true;
-        } catch (Exception &e) {
-            throw IOException("adbc_insert: Failed to execute insert: " + string(e.what()));
-        }
+    if (global_state.stream_bound && !global_state.exec_ok) {
+        throw IOException("adbc_insert: Failed to execute insert: " + global_state.exec_error);
     }
 
-    // Output the total rows inserted
+    // Output the total rows inserted (producer-side count is reliable across all
+    // drivers; the driver's rows_affected is advisory).
     output.SetCardinality(1);
     output.SetValue(0, 0, Value::BIGINT(global_state.rows_inserted));
 

--- a/src/adbc_insert.cpp
+++ b/src/adbc_insert.cpp
@@ -22,7 +22,11 @@ using namespace duckdb;
 // full source size. Overridable via ADBC_INSERT_MAX_PENDING_BATCHES.
 static constexpr size_t DEFAULT_MAX_PENDING_BATCHES = 32;
 
-static size_t ResolveMaxPendingBatches() {
+static size_t ResolveMaxPendingBatches(int64_t override_value) {
+    // Per-call named parameter wins, then the env override, then the default.
+    if (override_value > 0) {
+        return static_cast<size_t>(override_value);
+    }
     const char *env = std::getenv("ADBC_INSERT_MAX_PENDING_BATCHES");
     if (env && *env) {
         char *end = nullptr;
@@ -41,6 +45,10 @@ struct AdbcInsertBindData : public TableFunctionData {
     shared_ptr<AdbcConnectionWrapper> connection;
     vector<LogicalType> input_types;
     vector<string> input_names;
+    // Per-call override for the bounded-queue depth (0 = fall back to
+    // ADBC_INSERT_MAX_PENDING_BATCHES / the built-in default). Lets callers with
+    // fat rows (e.g. raster BLOB blocks) cap memory tighter than the default.
+    int64_t max_batches = 0;
 };
 
 // Bounded, blocking ArrowArrayStream bridging the DuckDB producer and the ADBC
@@ -297,6 +305,12 @@ static unique_ptr<FunctionData> AdbcInsertBind(ClientContext &context, TableFunc
         bind_data->mode = "append";  // Default to append
     }
 
+    // Optional per-call queue-depth override.
+    auto mb_it = input.named_parameters.find("max_batches");
+    if (mb_it != input.named_parameters.end() && !mb_it->second.IsNull()) {
+        bind_data->max_batches = mb_it->second.GetValue<int64_t>();
+    }
+
     // Get and validate connection
     bind_data->connection = GetValidatedConnection(bind_data->connection_id, "adbc_insert");
 
@@ -337,7 +351,7 @@ static unique_ptr<GlobalTableFunctionState> AdbcInsertInitGlobal(ClientContext &
     global_state->statement->SetOption("adbc.ingest.mode", mode_value);
 
     // Create the bounded insert stream
-    global_state->insert_stream = make_uniq<AdbcInsertStream>(ResolveMaxPendingBatches());
+    global_state->insert_stream = make_uniq<AdbcInsertStream>(ResolveMaxPendingBatches(bind_data.max_batches));
 
     // Set up the schema from the input types
     ArrowSchema schema;
@@ -430,12 +444,14 @@ void RegisterAdbcInsertFunction(DatabaseInstance &db) {
     adbc_insert_function.in_out_function = AdbcInsertInOut;
     adbc_insert_function.in_out_function_final = AdbcInsertFinalize;
     adbc_insert_function.named_parameters["mode"] = LogicalType::VARCHAR;
+    // Optional bounded-queue depth override (default 32 / ADBC_INSERT_MAX_PENDING_BATCHES).
+    adbc_insert_function.named_parameters["max_batches"] = LogicalType::BIGINT;
 
     CreateTableFunctionInfo info(adbc_insert_function);
     FunctionDescription desc;
     desc.description = "Bulk insert data from a query into an ADBC table";
-    desc.parameter_names = {"connection_handle", "table_name", "data", "mode"};
-    desc.parameter_types = {LogicalType::BIGINT, LogicalType::VARCHAR, LogicalType::TABLE, LogicalType::VARCHAR};
+    desc.parameter_names = {"connection_handle", "table_name", "data", "mode", "max_batches"};
+    desc.parameter_types = {LogicalType::BIGINT, LogicalType::VARCHAR, LogicalType::TABLE, LogicalType::VARCHAR, LogicalType::BIGINT};
     desc.examples = {"SELECT * FROM adbc_insert(conn, 'target_table', (SELECT * FROM source_table))",
                      "SELECT * FROM adbc_insert(conn, 'target', (SELECT * FROM source), mode := 'create')",
                      "SELECT * FROM adbc_insert(conn, 'target', (SELECT * FROM source), mode := 'append')"};


### PR DESCRIPTION
## Problem

`adbc_insert` materializes the **entire** input relation in memory before any rows reach the driver, so peak RSS grows with source size (`O(rows)`).

Two things combine to cause it:

1. **`pending_batches` is unbounded** — `AddBatch` pushes every converted `DataChunk` with no size cap or backpressure.
2. **`ExecuteUpdate` runs only in `AdbcInsertFinalize`** — i.e. *after* every `AdbcInsertInOut` call has already enqueued its batch. So the driver never consumes a single batch until the whole stream is buffered. (The old `GetNext` even had an `EAGAIN`/"this shouldn't happen" branch documenting that it was never expected to run before everything was queued.)

We hit this ingesting large datasets into Snowflake via DuckDB: a ~1 GB source drove ~6 GB RSS in the worker (and OOM-killed at 2 GB), even though the Snowflake ADBC driver itself ingests as a bounded streaming pipeline.

## Fix

Run `ExecuteUpdate` on a **background thread** started in `InitGlobal`, feeding a **bounded, blocking queue**:

- `AddBatch` (producer) blocks on a condition variable when the queue is full → backpressure; the DuckDB pipeline stops decoding ahead of the driver.
- `GetNext` (consumer, driven by `ExecuteUpdate` on the bg thread) blocks when empty until a batch arrives or the stream is finished; notifies the producer on each pop.
- `Abort()` + consumer-stop signalling + a `GlobalState` destructor join guarantee neither side deadlocks on error or query cancellation; producer errors and driver errors are both surfaced as the query error.

Queue depth is overridable via `ADBC_INSERT_MAX_PENDING_BATCHES` (default 32). Memory is now bounded by `max_batches × chunk_size` rather than the full source. No ABI/signature change; provider-agnostic.

## Evidence

Local A/B against the SQLite ADBC driver (same code path, `adbc_insert` → `BindStream` → `ExecuteUpdate` → `GetNext`), 5M-row source:

| build | insert-phase Δpeak RSS | rows | wall |
|---|---|---|---|
| before | **+1045 MB** (buffers whole input) | 5M ✓ | 2.0s |
| after (bounded, 32) | **+18 MB** | 5M ✓ | 1.9s |

At 10M rows the patched Δpeak stays ~31 MB (independent of source size); before scales with N. Same row counts, same wall time.

## Notes

- Single-producer is preserved (`MaxThreads()==1`); only one extra consumer thread is introduced.
- The statement is touched by one thread at a time (main binds in `InitGlobal`, then the bg thread executes); the shared `ArrowArrayStream` is mutex-guarded.
